### PR TITLE
Add/remove tracking bindings from models that have been edited

### DIFF
--- a/source/session/scene/package.d
+++ b/source/session/scene/package.d
@@ -48,21 +48,22 @@ struct SceneItem {
     }
 
     void genBindings() {
-        // Reset bindings
-        bindings.length = 0;
-
         struct LinkSrcDst {
-            Parameter src;
             Parameter dst;
-            int inAxis;
             int outAxis;
         }
         LinkSrcDst[] srcDst;
 
+        // Note down link targets
         foreach(param; puppet.parameters) {
             foreach(ref ParamLink link; param.links) {
-                srcDst ~= LinkSrcDst(param, link.link, cast(int)link.outAxis);
+                srcDst ~= LinkSrcDst(link.link, cast(int)link.outAxis);
             }
+        }
+
+        // Note existing bindings
+        foreach(binding; bindings) {
+            srcDst ~= LinkSrcDst(binding.param, binding.axis);
         }
 
         bool isParamAxisLinked(Parameter dst, int axis) {
@@ -113,8 +114,10 @@ void insSceneAddPuppet(string path, Puppet puppet) {
     item.filePath = path;
     item.puppet = puppet;
     if (!item.tryLoadBindings()) {
-        item.genBindings();
+        // Reset bindings
+        item.bindings.length = 0;
     }
+    item.genBindings();
 
     insScene.sceneItems ~= item;
 }

--- a/source/session/scene/package.d
+++ b/source/session/scene/package.d
@@ -38,10 +38,15 @@ struct SceneItem {
 
     bool tryLoadBindings() {
         if ("com.inochi2d.inochi-session.bindings" in puppet.extData) {
-            bindings = deserialize!(TrackingBinding[])(cast(string)puppet.extData["com.inochi2d.inochi-session.bindings"]);
+            auto preBindings = deserialize!(TrackingBinding[])(cast(string)puppet.extData["com.inochi2d.inochi-session.bindings"]);
 
             // finalize the loading
-            foreach(ref binding; bindings) binding.finalize(puppet);            
+            bindings = [];
+            foreach(ref binding; preBindings) {
+                if (binding.finalize(puppet)) {
+                    bindings ~= binding;
+                }
+            }
             return true;
         }
         return false;
@@ -62,7 +67,7 @@ struct SceneItem {
         }
 
         // Note existing bindings
-        foreach(binding; bindings) {
+        foreach(ref binding; bindings) {
             srcDst ~= LinkSrcDst(binding.param, binding.axis);
         }
 

--- a/source/session/tracking/package.d
+++ b/source/session/tracking/package.d
@@ -246,10 +246,13 @@ public:
     }
 
     /**
-        Finalizes the tracking binding
+        Finalizes the tracking binding, if possible.
+        Returns true on success.
+        Returns false if the parameter does not exist.
     */
-    void finalize(ref Puppet puppet) {
+    bool finalize(ref Puppet puppet) {
         param = puppet.findParameter(paramUUID);
+        return param !is null;
     }
 
     /**


### PR DESCRIPTION
Ran into some issues when working on a test model.
I added an expression, but it didn't show up in tracking.
So I've altered genBindings to add in bindings that didn't already exist, hopefully without disturbing existing bindings.

I then realized removing an expression could cause issues, so I tested that and got a crash, so I've made sure incompatible bindings are removed during the finalization stage.

The following model file is after an expression was removed:
[Silly.inx.zip](https://github.com/Inochi2D/inochi-session/files/9237256/Silly.inx.zip)
