### PR TITLE
Fix a crash when two sources are in a zone and the first is removed.

### DIFF
--- a/source/session/windows/spaceedit.d
+++ b/source/session/windows/spaceedit.d
@@ -160,6 +160,11 @@ public:
 
                     uiImIndent();
                         foreach(i; 0..editingZone.sources.length) {
+                            // Deleting a source causes some confusion here.
+                            if (i >= editingZone.sources.length) {
+                                continue;
+                            }
+
                             uiImPush(cast(int)i);
                                 auto source = editingZone.sources[i];
                                 const(char)* adaptorName = source is null ? __("Unset") : source.getAdaptorName().toStringz;


### PR DESCRIPTION
The crash can occur when deleting the first source in a setup such as this:
![image](https://user-images.githubusercontent.com/22304167/182670305-a0855d57-2a71-46e3-92fb-9336efe003af.png)

I'm unsure of if the fix should be done via this continue skip or via a more comprehensive solution like some sort of signalling from `adaptorMenu`.
