### PR TITLE
Ported issue templates to GitHub forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,79 @@
+name: Bug Report
+description: Report an issue with Inochi Session
+title: "[BUG]"
+labels: bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: checkboxes
+    id: checkboxes
+    attributes:
+      label: Validations
+      description: Before submitting the bug report, please make sure you do the following
+      options:
+        - label: I have checked for similar bug reports and could not find any.
+          required: true
+        - label: I have tested and confirmed that this is an issue in an official branded build.
+          required: true
+  - type: textarea
+    id: bug-description
+    attributes:
+      label: Describe the bug
+      description: A clear and concise description of what the bug is, and the behavior you expect instead. If you intend to submit a PR for this issue, tell us in the description. Thanks!
+      placeholder: I am doing ... What I expect is ...  What is actually happening is ...
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: Steps to reproduce the behavior
+      placeholder: |
+        1. Go to '...'
+        2. Click on '...'
+        3. Scroll down to '...'
+        4. See error
+    validations:
+      required: true
+  - type: dropdown
+    id: sys-arch
+    attributes:
+      label: System Architecture
+      options:
+        - x86_64
+        - arm64 / aarch64
+  - type: dropdown
+    id: sys-os
+    attributes:
+      label: Operating System
+      options:
+        - Windows
+        - macOS
+        - Linux
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: The version of Inochi Session you are running, or the commit hash if you are running a nightly / main branch build
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: |
+        Optional. If applicable, provide logs using the format below:
+        ````
+        <details>
+        <summary>Click to expand!</summary>
+        ```
+        // paste the log text here
+        ```
+        </details>
+        ````
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: |
+        Any other context or screenshots about the issue here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Discord Chat
+    url: https://discord.com/invite/abnxwN6r9v
+    about: Ask questions and discuss with other Inochi2D users in real time.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,48 @@
+name: Feature request
+description: Suggest an idea for Inochi Session
+title: "[Feature Request]"
+labels: enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for your interest in the project and taking the time to fill out this feature request!
+  - type: checkboxes
+    id: checkboxes
+    attributes:
+      label: Validations
+      description: Before submitting the feature request, please make sure you do the following
+      options:
+        - label: I have checked for similar feature requests and could not find any.
+          required: true
+        - label: I have made sure this is not an already-existing feature.
+          required: true
+  - type: textarea
+    id: feature-description
+    attributes:
+      label: Description
+      description: |
+        Clear and concise description of the problem being solved. Please make the reason and usecases as detailed as possible. If you intend to submit a PR for this issue, tell us in the description. Thanks!
+      placeholder: When using Inochi Session, I would like to be able to [goal / wish] so that [benefit].
+    validations:
+      required: true
+  - type: textarea
+    id: suggested-solution
+    attributes:
+      label: Suggested solution
+      description: |
+        A possible implementation to solve the problem.
+    validations:
+      required: true
+  - type: textarea
+    id: alternative
+    attributes:
+      label: Alternative solution
+      description: |
+        A different possible solution to solve the problem.
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: |
+        Any other context or screenshots about the issue here.


### PR DESCRIPTION
Converted issue templates into GitHub Forms to make it more structured. I've also added a link to the Inochi2D discord to redirect support requests to.
Live preview at https://github.com/HigasaMitsue/inochi-session/issues/new/choose
Let me know if there's anything to add, remove, or change in wording.

Excluded i686 as per discussion on discord.