### PR TITLE
Pass AppImage arguments into the executable

### DIFF
--- a/res/AppRun
+++ b/res/AppRun
@@ -2,4 +2,4 @@
 
 HERE="$(dirname "$(readlink -f "${0}")")"
 EXEC="${HERE}/usr/bin/inochi-session"
-LD_LIBRARY_PATH="${HERE}/usr/lib" exec "${EXEC}"
+LD_LIBRARY_PATH="${HERE}/usr/lib" exec "${EXEC}" "$@"


### PR DESCRIPTION
Currently the AppImage is not passing the arguments (also see https://discourse.appimage.org/t/command-line-parameter-transfer/1537)