### PR TITLE
Fix crash when trying to create adaptors that don't exist

### DIFF
--- a/source/session/tracking/vspace.d
+++ b/source/session/tracking/vspace.d
@@ -266,6 +266,7 @@ public:
                         xdata["appName"] = "inochi-session";
                         if (type == "VMC Receiver") xdata["address"] = "0.0.0.0";
                         adaptor = ftCreateAdaptor(type);
+                        if(adaptor is null) continue;
                         adaptor.setOptions(xdata);
 
                         if (adaptor) sources ~= adaptor;
@@ -276,6 +277,7 @@ public:
                         xdata["appName"] = "inochi-session";
                         if (type == "VMC Receiver") xdata["address"] = "0.0.0.0";
                         adaptor = ftCreateAdaptor(type);
+                        if(adaptor is null) continue;
                         adaptor.setOptions(xdata);
                     
                         if (adaptor) sources ~= adaptor;


### PR DESCRIPTION
inochi-session crashes when it tries to load adaptors that appear on the configuration file, but don't actually exist on the application. This patch fixes that.