### PR TITLE
Stop forcing X11 on Linux

### DIFF
--- a/source/app.d
+++ b/source/app.d
@@ -22,9 +22,6 @@ import std.process;
 
 void main(string[] args) {
     insLogInfo("Inochi Session %s, args=%s", INS_VERSION, args[1..$]);
-    
-    // Force X11 as the video driver on Linux
-    version(linux) environment["SDL_VIDEODRIVER"] = "x11";
 
     // Set the application info
     InApplication appInfo = InApplication(


### PR DESCRIPTION
SDL already uses X by default, even if Wayland is available. Additionally, the flatpak would use X anyways, since SDL isn't all that great on Wayland (without SSDs), as the Flatpak sandbox isn't very friendly with SDL and libdecor.