### PR TITLE
Fix crash when there are no zones.

### DIFF
--- a/source/session/tracking/vspace.d
+++ b/source/session/tracking/vspace.d
@@ -177,7 +177,7 @@ public:
     }
 
     bool isCurrentZoneActive() {
-        return currentZone.sources.length > 0 && currentZone.sources[0] && currentZone.sources[0].isReceivingData;
+        return currentZone !is null && currentZone.sources.length > 0 && currentZone.sources[0] && currentZone.sources[0].isReceivingData;
     }
 
     /**


### PR DESCRIPTION
This fixes a crash in the nightly version. This is not related to #23, but can be reproduced the same way or by simply trying to start the app without a config file.