### PR TITLE
Phiz Adaptors

### DIFF
--- a/source/session/tracking/vspace.d
+++ b/source/session/tracking/vspace.d
@@ -265,7 +265,7 @@ public:
                         // NOTE: inochi-session should ALWAYS be the appName.
                         xdata["appName"] = "inochi-session";
                         if (type == "VMC Receiver") xdata["address"] = "0.0.0.0";
-                        if (type == "Phiz Receiver") xdata["address"] = "0.0.0.0";
+                        if (type == "Phiz OSC Receiver") xdata["address"] = "0.0.0.0";
                         adaptor = ftCreateAdaptor(type);
                         if(adaptor is null) continue;
                         adaptor.setOptions(xdata);
@@ -277,7 +277,7 @@ public:
                         // NOTE: inochi-session should ALWAYS be the appName.
                         xdata["appName"] = "inochi-session";
                         if (type == "VMC Receiver") xdata["address"] = "0.0.0.0";
-                        if (type == "Phiz Receiver") xdata["address"] = "0.0.0.0";
+                        if (type == "Phiz OSC Receiver") xdata["address"] = "0.0.0.0";
                         adaptor = ftCreateAdaptor(type);
                         if(adaptor is null) continue;
                         adaptor.setOptions(xdata);

--- a/source/session/tracking/vspace.d
+++ b/source/session/tracking/vspace.d
@@ -265,6 +265,7 @@ public:
                         // NOTE: inochi-session should ALWAYS be the appName.
                         xdata["appName"] = "inochi-session";
                         if (type == "VMC Receiver") xdata["address"] = "0.0.0.0";
+                        if (type == "Phiz Receiver") xdata["address"] = "0.0.0.0";
                         adaptor = ftCreateAdaptor(type);
                         if(adaptor is null) continue;
                         adaptor.setOptions(xdata);
@@ -276,6 +277,7 @@ public:
                         // NOTE: inochi-session should ALWAYS be the appName.
                         xdata["appName"] = "inochi-session";
                         if (type == "VMC Receiver") xdata["address"] = "0.0.0.0";
+                        if (type == "Phiz Receiver") xdata["address"] = "0.0.0.0";
                         adaptor = ftCreateAdaptor(type);
                         if(adaptor is null) continue;
                         adaptor.setOptions(xdata);

--- a/source/session/windows/spaceedit.d
+++ b/source/session/windows/spaceedit.d
@@ -122,6 +122,15 @@ private:
                 editingZone.sources[i] = source;
                 refreshOptionsList();
             }
+            version (Phiz) {
+                if (uiImSelectable("Phiz Receiver")) {
+                    if (source) source.stop();
+
+                    source = new PhizAdaptor();
+                    editingZone.sources[i] = source;
+                    refreshOptionsList();
+                }
+            }
             version (WebHookAdaptor) {
                 if (uiImSelectable("WebHook Receiver")) {
                     if (source) source.stop();

--- a/source/session/windows/spaceedit.d
+++ b/source/session/windows/spaceedit.d
@@ -101,10 +101,10 @@ private:
                 editingZone.sources[i] = source;
                 refreshOptionsList();
             }
-            if (uiImSelectable("Phiz")) {
+            if (uiImSelectable("Phiz OSC")) {
                 if (source) source.stop();
 
-                source = new PhizAdaptor();
+                source = new PhizOSCAdaptor();
                 editingZone.sources[i] = source;
                 refreshOptionsList();
             }

--- a/source/session/windows/spaceedit.d
+++ b/source/session/windows/spaceedit.d
@@ -101,6 +101,13 @@ private:
                 editingZone.sources[i] = source;
                 refreshOptionsList();
             }
+            if (uiImSelectable("Phiz")) {
+                if (source) source.stop();
+
+                source = new PhizAdaptor();
+                editingZone.sources[i] = source;
+                refreshOptionsList();
+            }
             if (uiImSelectable("OpenSeeFace")) {
                 if (source) source.stop();
 


### PR DESCRIPTION
Yesterday searching for things about mocap I found this project https://www.phizmocap.dev. Since it implements exporting tracking values and blendshapes through OSC, I implemented it in facetrack-d and session for testing purposes.

My first impression is that it's easier to use than OSF, but I still have my concerns considering that it runs on a webpage on the browser (and I still haven't had the chance to study that part).

To test this, you also need the PR branch from facetrack-d

https://github.com/Inochi2D/facetrack-d/pull/16

Edit: Besides the OSC protocol that needs an app to use, it provides a more direct websocket protocol that works with apps running in localhost. Implemented that too :)