### PR TITLE
Animation control system

### DIFF
--- a/source/session/animation/package.d
+++ b/source/session/animation/package.d
@@ -1,0 +1,151 @@
+module session.animation;
+
+import session.tracking;
+import inochi2d.core.animation;
+import inochi2d.core.animation.player;
+import fghj;
+import i18n;
+import std.format;
+
+enum TriggerType {
+    None,
+    TrackingTrigger,
+    EventTrigger
+}
+
+enum TriggerEvent {
+    None,
+    TrackingOff,
+    TrackingOn,
+}
+
+class AnimationControl {
+public:
+    string name;
+    bool loop = true;
+    bool inmediateStop = false;
+
+    TriggerType type = TriggerType.None;
+
+    // Binding
+    string sourceName;
+    string sourceDisplayName;
+    SourceType sourceType;
+    bool inverse;
+    float leadInValue = 1;
+    float leadOutValue = 0;
+    float fullStopValue = -1;
+
+    // EventBidning
+    TriggerEvent leadInEvent;
+    TriggerEvent leadOutEvent;
+    TriggerEvent fullStopEvent;
+
+    // Util
+    AnimationPlaybackRef anim; 
+
+    void serialize(S)(ref S serializer) {
+        auto state = serializer.objectBegin;
+            serializer.putKey("name");
+            serializer.putValue(name);
+            serializer.putKey("loop");
+            serializer.putValue(loop);
+            serializer.putKey("inmediateStop");
+            serializer.putValue(inmediateStop);
+            serializer.putKey("triggerType");
+            serializer.serializeValue(type);
+
+            switch(type) {
+                case TriggerType.TrackingTrigger:
+                    serializer.putKey("sourceName");
+                    serializer.putValue(sourceName);
+                    serializer.putKey("sourceType");
+                    serializer.serializeValue(sourceType);
+
+                    serializer.putKey("inverse");
+                    serializer.putValue(inverse);
+
+                    serializer.putKey("leadInValue");
+                    serializer.putValue(leadInValue);
+                    serializer.putKey("leadOutValue");
+                    serializer.putValue(leadOutValue);
+                    serializer.putKey("fullStopValue");
+                    serializer.putValue(fullStopValue);
+                    break;
+                case TriggerType.EventTrigger:
+                    serializer.putKey("leadInEvent");
+                    serializer.serializeValue(leadInEvent);
+                    serializer.putKey("leadOutEvent");
+                    serializer.serializeValue(leadOutEvent);
+                    serializer.putKey("fullStopEvent");
+                    serializer.serializeValue(fullStopEvent);
+                    break;
+                default: break;
+            }
+
+        serializer.objectEnd(state);
+    }
+
+    SerdeException deserializeFromFghj(Fghj data) {
+        data["name"].deserializeValue(name);
+        data["loop"].deserializeValue(loop);
+        data["inmediateStop"].deserializeValue(inmediateStop);
+        data["triggerType"].deserializeValue(type);
+
+        switch(type) {
+            case TriggerType.TrackingTrigger:
+                data["sourceName"].deserializeValue(sourceName);
+                data["sourceType"].deserializeValue(sourceType);
+
+                data["inverse"].deserializeValue(inverse);
+                
+                data["leadInValue"].deserializeValue(leadInValue);
+                data["leadOutValue"].deserializeValue(leadOutValue);
+                data["fullStopValue"].deserializeValue(fullStopValue);
+                this.createSourceDisplayName();
+                break;
+            case TriggerType.EventTrigger:
+                data["leadInEvent"].deserializeValue(leadInValue);
+                data["leadOutEvent"].deserializeValue(leadOutValue);
+                data["fullStopEvent"].deserializeValue(fullStopValue);
+                break;
+            default: break;
+        }
+                
+        return null;
+    }
+
+    bool finalize(ref AnimationPlayer player) {
+        anim = player.createOrGet(name);
+        return anim !is null;
+
+    }
+
+    void createSourceDisplayName() {
+        switch(sourceType) {
+            case SourceType.Blendshape:
+                sourceDisplayName = sourceName;
+                break;
+            case SourceType.BonePosX:
+                sourceDisplayName = _("%s (X)").format(sourceName);
+                break;
+            case SourceType.BonePosY:
+                sourceDisplayName = _("%s (Y)").format(sourceName);
+                break;
+            case SourceType.BonePosZ:
+                sourceDisplayName = _("%s (Z)").format(sourceName);
+                break;
+            case SourceType.BoneRotRoll:
+                sourceDisplayName = _("%s (Roll)").format(sourceName);
+                break;
+            case SourceType.BoneRotPitch:
+                sourceDisplayName = _("%s (Pitch)").format(sourceName);
+                break;
+            case SourceType.BoneRotYaw:
+                sourceDisplayName = _("%s (Yaw)").format(sourceName);
+                break;
+            default: assert(0);    
+        }
+    }
+
+}

--- a/source/session/panels/animations.d
+++ b/source/session/panels/animations.d
@@ -1,0 +1,67 @@
+module session.panels.animations;
+import inui.panel;
+import i18n;
+import session.scene;
+import inui.widgets;
+import std.string;
+import std.algorithm.searching;
+import inochi2d.core.animation.player;
+import inmath;
+
+class AnimationsPanel : Panel {
+    string _selected;
+    immutable(char) * _selectedCName;
+    string _selectFilter;
+
+protected:
+
+    override 
+    void onUpdate() {
+        auto item = insSceneSelectedSceneItem();
+        if (item) {
+
+            if (uiImButton(__("Save to File"))) {
+                try {
+                    item.saveAnimations();
+                } catch (Exception ex) {
+                    uiImDialog(__("Error"), ex.msg);
+                }
+            }
+
+            foreach(ref ac; item.animations) {
+                uiImPush(&ac);
+                auto anim = ac.anim;
+                if (uiImHeader(ac.name.toStringz, true)) {
+
+                    if (uiImButton("")) {
+                        anim.stop(ac.inmediateStop);
+                    }
+                    uiImSameLine(0, 0);
+                    
+                    if (uiImButton(anim && !(!anim.playing || anim.paused) ? "" : "")) {
+                        if (!anim.playing || anim.paused) anim.play(ac.loop);
+                        else anim.pause();
+                    }
+                    uiImSameLine(0, 0);
+                    uiImProgress((cast(float)anim.frame) / anim.frames, vec2(-float.min_normal, 0), "");
+
+                    uiImCheckbox(__("Loop"), ac.loop);
+                    uiImCheckbox(__("Inmediate Stop"), ac.inmediateStop);
+
+                }
+                uiImPop();
+            }
+        } else {
+            uiImLabel(_("No puppet selected"));
+        }
+    }
+
+public:
+    this() {
+        super("Animations", _("Animations"), true);
+        _selected = _("Select an animation");
+        _selectedCName = _selected.toStringz;
+    }
+}
+
+mixin inPanel!AnimationsPanel;

--- a/source/session/panels/animations.d
+++ b/source/session/panels/animations.d
@@ -1,3 +1,8 @@
+/*
+    Distributed under the 2-Clause BSD License, see LICENSE file.
+
+    Authors: Grillo del Mal
+*/
 module session.panels.animations;
 import inui.panel;
 import i18n;
@@ -7,18 +12,285 @@ import std.string;
 import std.algorithm.searching;
 import inochi2d.core.animation.player;
 import inmath;
+import session.animation;
+import bindbc.imgui;
+
+private {
+    string trackingFilter;
+
+    struct TrackingSource {
+        bool isBone;
+        string name;
+        const(char)* cName;
+    }
+}
 
 class AnimationsPanel : Panel {
-    string _selected;
-    immutable(char) * _selectedCName;
-    string _selectFilter;
+private:
+    TrackingSource[] sources;
+    string[] indexableSourceNames;
 
+    // Refreshes the list of tracking sources
+    void refresh(ref AnimationControl[] animationControls) {
+        auto blendshapes = insScene.space.getAllBlendshapeNames();
+        auto bones = insScene.space.getAllBoneNames();
+        
+        sources.length = blendshapes.length + bones.length;
+        indexableSourceNames.length = sources.length;
+
+        foreach(i, blendshape; blendshapes) {
+            sources[i] = TrackingSource(
+                false,
+                blendshape,
+                blendshape.toStringz
+            );
+            indexableSourceNames[i] = blendshape.toLower;
+        }
+
+        foreach(i, bone; bones) {
+            sources[blendshapes.length+i] = TrackingSource(
+                true,
+                bone,
+                bone.toStringz
+            );
+
+            indexableSourceNames[blendshapes.length+i] = bone.toLower;
+        }
+
+        // Add any bindings unnacounted for which are stored in the model.
+        trkMain: foreach(ac; animationControls) {
+            
+            // Skip non-existent sources
+            if (ac.sourceName.length == 0) continue;
+
+            TrackingSource src = TrackingSource(
+                ac.sourceType != SourceType.Blendshape,
+                ac.sourceName,
+                ac.sourceName.toStringz
+            );
+
+            // Skip anything we already know
+            foreach(xsrc; sources) {
+                if (xsrc.isBone == src.isBone && xsrc.name == src.name) continue trkMain;
+            }
+
+            sources ~= src;
+            indexableSourceNames ~= src.name.toLower;
+        }
+    }
+
+    void trackingOptions(AnimationControl ac){
+        float default_val;
+        bool hasTrackingSrc = ac.sourceName.length > 0;
+        uiImIndent();
+
+        uiImLabel(_("Tracking Parameter"));
+        if (uiImBeginComboBox("SELECTION_COMBO", hasTrackingSrc ? ac.sourceDisplayName.toStringz : __("Not tracked"))) {
+            if (uiImInputText("###FILTER", uiImAvailableSpace().x, trackingFilter)) {
+                trackingFilter = trackingFilter.toLower();
+            }
+
+            uiImDummy(vec2(0, 8));
+
+            foreach(ix, source; sources) {
+                
+                if (trackingFilter.length > 0 && !indexableSourceNames[ix].canFind(trackingFilter)) continue;
+
+                bool selected = ac.sourceName == source.name;
+                bool nameValid = source.name.length > 0;
+                if (source.isBone) {
+                    if (uiImBeginMenu(source.cName)) {
+                        if (uiImMenuItem(__("X"))) {
+                            ac.sourceName = source.name;
+                            ac.sourceType = SourceType.BonePosX;
+                            ac.createSourceDisplayName();
+                            trackingFilter = null;
+                        }
+                        if (uiImMenuItem(__("Y"))) {
+                            ac.sourceName = source.name;
+                            ac.sourceType = SourceType.BonePosY;
+                            ac.createSourceDisplayName();
+                            trackingFilter = null;
+                        }
+                        if (uiImMenuItem(__("Z"))) {
+                            ac.sourceName = source.name;
+                            ac.sourceType = SourceType.BonePosZ;
+                            ac.createSourceDisplayName();
+                            trackingFilter = null;
+                        }
+                        if (uiImMenuItem(__("Roll"))) {
+                            ac.sourceName = source.name;
+                            ac.sourceType = SourceType.BoneRotRoll;
+                            ac.createSourceDisplayName();
+                            trackingFilter = null;
+                        }
+                        if (uiImMenuItem(__("Pitch"))) {
+                            ac.sourceName = source.name;
+                            ac.sourceType = SourceType.BoneRotPitch;
+                            ac.createSourceDisplayName();
+                            trackingFilter = null;
+                        }
+                        if (uiImMenuItem(__("Yaw"))) {
+                            ac.sourceName = source.name;
+                            ac.sourceType = SourceType.BoneRotYaw;
+                            ac.createSourceDisplayName();
+                            trackingFilter = null;
+                        }
+                        uiImEndMenu();
+                    }
+                } else {
+                    if (uiImSelectable(nameValid ? source.cName : "###NoName", selected)) {
+                        trackingFilter = null;
+                        ac.sourceType = SourceType.Blendshape;
+                        ac.sourceName = source.name;
+                        ac.createSourceDisplayName();
+                    }
+                }
+            }
+            uiImEndComboBox();
+        }
+
+        if (hasTrackingSrc) {
+            uiImSameLine(0, 4);
+            if (uiImButton(__("Reset"))){
+                ac.sourceName = null;
+            }
+        }
+
+        if (hasTrackingSrc) {
+            uiImProgress(ac.inValToBindingValue(), vec2(-float.min_normal, 0), "");
+            uiImDummy(vec2(0, 8));
+            uiImCheckbox(__("Default Thresholds"), ac.defaultThresholds);
+
+            if(ac.defaultThresholds){
+                igBeginDisabled();
+            }
+            uiImLabel(_("Play Threshold"));
+            uiImPush(0);
+                uiImIndent();
+                default_val = 1;
+                switch(ac.sourceType) {
+                    case SourceType.Blendshape:
+                        // TODO: Make all blendshapes in facetrack-d 0->1
+                        uiImDrag(ac.defaultThresholds ? default_val : ac.playThresholdValue, -1, 1);
+                        break;
+
+                    case SourceType.BonePosX:
+                    case SourceType.BonePosY:
+                    case SourceType.BonePosZ:
+                        uiImDrag(ac.defaultThresholds ? default_val : ac.playThresholdValue, -float.max, float.max);
+                        break;
+
+                    case SourceType.BoneRotPitch:
+                    case SourceType.BoneRotRoll:
+                    case SourceType.BoneRotYaw:
+                        uiImDrag(ac.defaultThresholds ? default_val : ac.playThresholdValue, -180, 180);
+                        break;
+                        
+                    default: assert(0);
+                }
+                uiImSameLine(0, 0);
+                if (uiImButton(
+                        thresholdDirectionIcon(ac.defaultThresholds ? ThresholdDir.Up : ac.playThresholdDir))) {
+                    if(ac.playThresholdDir < ThresholdDir.Both) ac.playThresholdDir += 1;
+                    else ac.playThresholdDir = ThresholdDir.None;
+                }
+
+                uiImUnindent();
+            uiImPop();
+            
+            uiImLabel(_("Stop Threshold"));
+            uiImPush(1);
+                uiImIndent();
+                default_val = 0;
+                switch(ac.sourceType) {
+                    case SourceType.Blendshape:
+                        // TODO: Make all blendshapes in facetrack-d 0->1
+                        uiImDrag(ac.defaultThresholds ? default_val : ac.stopThresholdValue, -1, 1);
+                        break;
+
+                    case SourceType.BonePosX:
+                    case SourceType.BonePosY:
+                    case SourceType.BonePosZ:
+                        uiImDrag(ac.defaultThresholds ? default_val : ac.stopThresholdValue, -float.max, float.max);
+                        break;
+
+                    case SourceType.BoneRotPitch:
+                    case SourceType.BoneRotRoll:
+                    case SourceType.BoneRotYaw:
+                        uiImDrag(ac.defaultThresholds ? default_val : ac.stopThresholdValue, -180, 180);
+                        break;
+                        
+                    default: assert(0);
+                }
+                uiImSameLine(0, 0);
+                if (uiImButton(
+                        thresholdDirectionIcon(ac.defaultThresholds ? ThresholdDir.Down : ac.stopThresholdDir))) {
+                    if(ac.stopThresholdDir < ThresholdDir.Both) ac.stopThresholdDir += 1;
+                    else ac.stopThresholdDir = ThresholdDir.None;
+                }
+                uiImUnindent();
+            uiImPop();
+
+            uiImLabel(_("Full Stop Threshold"));
+            uiImPush(2);
+                uiImIndent();
+                default_val = -1;
+                switch(ac.sourceType) {
+                    case SourceType.Blendshape:
+                        // TODO: Make all blendshapes in facetrack-d 0->1
+                        uiImDrag(ac.defaultThresholds ? default_val : ac.fullStopThresholdValue, -1, 1);
+                        break;
+
+                    case SourceType.BonePosX:
+                    case SourceType.BonePosY:
+                    case SourceType.BonePosZ:
+                        uiImDrag(ac.defaultThresholds ? default_val : ac.fullStopThresholdValue, -float.max, float.max);
+                        break;
+
+                    case SourceType.BoneRotPitch:
+                    case SourceType.BoneRotRoll:
+                    case SourceType.BoneRotYaw:
+                        uiImDrag(ac.defaultThresholds ? default_val : ac.fullStopThresholdValue, -180, 180);
+                        break;
+                        
+                    default: assert(0);
+                }
+                uiImSameLine(0, 0);
+                if (uiImButton(
+                        thresholdDirectionIcon(ac.defaultThresholds ? ThresholdDir.Down : ac.fullStopThresholdDir))) {
+                    if(ac.fullStopThresholdDir < ThresholdDir.Both) ac.fullStopThresholdDir += 1;
+                    else ac.fullStopThresholdDir = ThresholdDir.None;
+                }
+                uiImUnindent();
+            uiImPop();
+            if(ac.defaultThresholds){
+                igEndDisabled();
+            }
+
+        }
+        uiImUnindent();
+    }
+
+    void eventOptions(AnimationControl ac){
+        uiImIndent();
+            uiImLabel(_("TODO: Not yet implemented."));
+        uiImUnindent();
+        
+    }
 protected:
 
     override 
     void onUpdate() {
         auto item = insSceneSelectedSceneItem();
         if (item) {
+
+            if (uiImButton(__("Refresh"))) {
+                insScene.space.refresh();
+                refresh(item.animations);
+            }
+
+            uiImSameLine(0, 4);
 
             if (uiImButton(__("Save to File"))) {
                 try {
@@ -34,7 +306,7 @@ protected:
                 if (uiImHeader(ac.name.toStringz, true)) {
 
                     if (uiImButton("")) {
-                        anim.stop(ac.inmediateStop);
+                        anim.stop(igIsKeyDown(ImGuiKey.LeftShift) || igIsKeyDown(ImGuiKey.RightShift));
                     }
                     uiImSameLine(0, 0);
                     
@@ -46,7 +318,36 @@ protected:
                     uiImProgress((cast(float)anim.frame) / anim.frames, vec2(-float.min_normal, 0), "");
 
                     uiImCheckbox(__("Loop"), ac.loop);
-                    uiImCheckbox(__("Inmediate Stop"), ac.inmediateStop);
+
+                    uiImDummy(vec2(0, 12));
+
+                    uiImLabel(_("Trigger"));
+                    if (uiImBeginComboBox("ACType", triggerTypeString(ac.type))) {
+                        if (uiImSelectable(triggerTypeString(TriggerType.None))) {
+                            ac.type = TriggerType.None;
+                        }
+                        if (uiImSelectable(triggerTypeString(TriggerType.Tracking))) {
+                            ac.type = TriggerType.Tracking;
+                        }
+                        if (uiImSelectable(triggerTypeString(TriggerType.Event))) {
+                            ac.type = TriggerType.Event;
+                        }
+                        uiImEndComboBox();
+                    }
+
+                    uiImDummy(vec2(0, 8));
+
+                    switch(ac.type) {
+                        case TriggerType.Tracking:
+                            trackingOptions(ac);
+                            break;
+                        case TriggerType.Event:
+                            eventOptions(ac);
+                            break;
+                        default: break;
+                    }
+
+                    uiImDummy(vec2(0, 8));
 
                 }
                 uiImPop();
@@ -59,8 +360,6 @@ protected:
 public:
     this() {
         super("Animations", _("Animations"), true);
-        _selected = _("Select an animation");
-        _selectedCName = _selected.toStringz;
     }
 }
 

--- a/source/session/scene/package.d
+++ b/source/session/scene/package.d
@@ -317,6 +317,7 @@ void insUpdateScene() {
             if (insScene.zoneInactiveTimer >= 5) {
                 foreach(ref sceneItem; insScene.sceneItems) {
                     if (sceneItem.sleepAnim && !sceneItem.sleepAnim.playing()) {
+                        sceneItem.player.stopAll(true);
                         sceneItem.sleepAnim.strength = 1;
                         sceneItem.sleepAnim.play(true);
                     }

--- a/source/session/scene/package.d
+++ b/source/session/scene/package.d
@@ -178,6 +178,7 @@ void insSceneAddPuppet(string path, Puppet puppet) {
         // Reset animations
         item.animations.length = 0;
     }
+
     item.genBindings();
     item.genAnimationControls();
 
@@ -333,6 +334,10 @@ void insUpdateScene() {
             
             foreach(ref binding; sceneItem.bindings) {
                 binding.update();
+            }
+
+            foreach(ref ac; sceneItem.animations) {
+                ac.update();
             }
 
             sceneItem.player.update(deltaTime());


### PR DESCRIPTION
This PR implements the feature described in #37. The main idea is to enable a system to use puppet animations in inochi-session, either by manual interaction with the UI, or by triggering them using external tracking parameters.

In this video I show how they can be triggered by a keyboard combination using puppetstring and by head motion.

[session-animation-demo.webm](https://github.com/Inochi2D/inochi-session/assets/11585030/249dc685-e186-40a5-826b-12af972d7836)

Here is the list of the implemented features:

- [x] Play/Pause/Stop animations
- [x] Loop control
- [x] Trigger by tracking
  - [x] Set custom trigger values
  - [x] Control trigger value direction
- [x] Save/Load animation control config in puppet

Some other things that I thought of that could get implemented too further along the line

* Trigger by event system
  * Event Queue
  * Implement tracking disconnected/reconnected as Event
  * Move `tracking_lost` animation to this system.
* Animation weight
  * Use `additive` and `weight` parameters.
  * Evaluate weighed fadein - fadeout options.

I'm still not sure if I want to implement the "Trigger by event" feature considering that currently the only application events I can imagine are "tracking lost" and "reconnect tracking", and those events are already being handled by setting a "tracking_lost" animation.

Its lots of code, so I would appreciate feedback on this feature :)