### PR TITLE
Added visual-studio (.vs) to git-ignore for visual-studio users.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .dub
+.vs
 docs.json
 __dummy.html
 docs/


### PR DESCRIPTION
Visual studio automatically adds files to the `.vs` directory. Adding this to git-ignore will simplify committing for those of us using visual-studio in windows environments. 