### PR TITLE
Fix requesting bone data to empty source

### DIFF
--- a/source/session/tracking/vspace.d
+++ b/source/session/tracking/vspace.d
@@ -339,6 +339,7 @@ public:
         if (sources.length > 1) {
             float count = 1;
             foreach(ref source; sources[1..$]) {
+                if(!source) continue;
                 if (name in source.getBones) {
                     count += 1;
 


### PR DESCRIPTION
Fixes #54 

This is a simple fix, since this was already resolved for blendshapes

https://github.com/Inochi2D/inochi-session/blob/755015c5c4a68cbe647ad4588955cbc13646d32a/source/session/tracking/vspace.d#L312

So we do the same for the bones.