### PR TITLE
Add "Hold Delay" option to tracking animation triggers

### DIFF
--- a/source/session/panels/animations.d
+++ b/source/session/panels/animations.d
@@ -81,6 +81,7 @@ private:
 
     void trackingOptions(AnimationControl ac){
         float default_val;
+        int default_hold_val = 0;
         bool hasTrackingSrc = ac.sourceName.length > 0;
         uiImIndent();
 
@@ -161,6 +162,10 @@ private:
             uiImProgress(ac.inValToBindingValue(), vec2(-float.min_normal, 0), "");
             uiImDummy(vec2(0, 8));
             uiImCheckbox(__("Default Thresholds"), ac.defaultThresholds);
+            uiImSameLine(0, 0);
+            uiImDummy(vec2(10, 5));
+            uiImSameLine(0, 0);
+            uiImCheckbox(__("Use Hold Delay"), ac.useHoldDelay);
 
             if(ac.defaultThresholds){
                 igBeginDisabled();
@@ -194,6 +199,20 @@ private:
                         thresholdDirectionIcon(ac.defaultThresholds ? ThresholdDir.Up : ac.playThresholdDir))) {
                     if(ac.playThresholdDir < ThresholdDir.Both) ac.playThresholdDir += 1;
                     else ac.playThresholdDir = ThresholdDir.None;
+                }
+                if(ac.useHoldDelay){
+                    if(ac.playThresholdDir == ThresholdDir.None || ac.playThresholdDir == ThresholdDir.Both){
+                        igBeginDisabled();
+                    }
+                    uiImLabel(_("Hold Delay (ms):"));
+                    uiImPush(0);
+                    uiImDrag(
+                        ac.defaultThresholds || ac.playThresholdDir == ThresholdDir.None || ac.playThresholdDir == ThresholdDir.Both ? 
+                            default_hold_val : ac.playThresholdHoldDelay, 0, int.max);
+                    uiImPop();
+                    if(ac.playThresholdDir == ThresholdDir.None || ac.playThresholdDir == ThresholdDir.Both){
+                        igEndDisabled();
+                    }
                 }
 
                 uiImUnindent();
@@ -229,6 +248,20 @@ private:
                     if(ac.stopThresholdDir < ThresholdDir.Both) ac.stopThresholdDir += 1;
                     else ac.stopThresholdDir = ThresholdDir.None;
                 }
+                if(ac.useHoldDelay){
+                    if(ac.stopThresholdDir == ThresholdDir.None || ac.stopThresholdDir == ThresholdDir.Both){
+                        igBeginDisabled();
+                    }
+                    uiImLabel(_("Hold Delay (ms):"));
+                    uiImPush(0);
+                    uiImDrag(
+                        ac.defaultThresholds || ac.stopThresholdDir == ThresholdDir.None || ac.stopThresholdDir == ThresholdDir.Both ? 
+                            default_hold_val : ac.stopThresholdHoldDelay, 0, int.max);
+                    uiImPop();
+                    if(ac.stopThresholdDir == ThresholdDir.None || ac.stopThresholdDir == ThresholdDir.Both){
+                        igEndDisabled();
+                    }
+                }
                 uiImUnindent();
             uiImPop();
 
@@ -261,6 +294,20 @@ private:
                         thresholdDirectionIcon(ac.defaultThresholds ? ThresholdDir.Down : ac.fullStopThresholdDir))) {
                     if(ac.fullStopThresholdDir < ThresholdDir.Both) ac.fullStopThresholdDir += 1;
                     else ac.fullStopThresholdDir = ThresholdDir.None;
+                }
+                if(ac.useHoldDelay){
+                    if(ac.fullStopThresholdDir == ThresholdDir.None || ac.fullStopThresholdDir == ThresholdDir.Both){
+                        igBeginDisabled();
+                    }
+                    uiImLabel(_("Hold Delay (ms):"));
+                    uiImPush(0);
+                    uiImDrag(
+                        ac.defaultThresholds || ac.fullStopThresholdDir == ThresholdDir.None || ac.fullStopThresholdDir == ThresholdDir.Both ? 
+                            default_hold_val : ac.fullStopThresholdHoldDelay, 0, int.max);
+                    uiImPop();
+                    if(ac.fullStopThresholdDir == ThresholdDir.None || ac.fullStopThresholdDir == ThresholdDir.Both){
+                        igEndDisabled();
+                    }
                 }
                 uiImUnindent();
             uiImPop();


### PR DESCRIPTION
Currently, when you setup animations to trigger by tracking, they will trigger as soon as they reach the threshold.
This PR adds an option to require for the value to be held for an amount of time before it's marked as triggered.

https://github.com/Inochi2D/inochi-session/assets/11585030/fd531221-42b2-42f7-8c46-fc1575876ef1

I envisioned this feature after helping ✦ Licore ✦ with her [mic tracked project](https://discord.com/channels/855173611409506334/1239341640997404736).

I marked this as a draft since it was built over the same branch as #56 . I plan to separate this later.

Kudos to @Anasu and ✦ Licore ✦ for their valuable input.